### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://techmerck.visualstudio.com/30073487-0728-4205-9c7c-8008ee110bac/3ab62ed8-3037-4b71-ae58-1e10a8724819/_apis/work/boardbadge/072d2d2f-fac7-40df-977e-d7827b97987e)](https://techmerck.visualstudio.com/30073487-0728-4205-9c7c-8008ee110bac/_boards/board/t/3ab62ed8-3037-4b71-ae58-1e10a8724819/Microsoft.RequirementCategory)
 # issues-integration-test
 Testing issues integration from GH to ADO. Public GH repo to team work in ADO.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#931](https://techmerck.visualstudio.com/30073487-0728-4205-9c7c-8008ee110bac/_workitems/edit/931). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.